### PR TITLE
Add blzlib_log.h to installed headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(blz-scan-discover blzlib ${LIBSYSTEMD_LIBRARIES})
 
 set(CMAKE_C_FLAGS "-DDEBUG=1")
 
-install(FILES blzlib.h blzlib_util.h
+install(FILES blzlib.h blzlib_util.h blzlib_log.h
 	DESTINATION include
 )
 


### PR DESCRIPTION
Installing blzlib_log.h allows users of the library to disable logging
output of the library.

Signed-off-by: Anthony Brandon <anthony@amarulasolutions.com>